### PR TITLE
Updates `Makevars`-files from latest rextendr

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,5 @@
-LIBDIR = ./rust/target/release
+TARGET_DIR = ./rust/target
+LIBDIR = $(TARGET_DIR)/release
 STATLIB = $(LIBDIR)/libh3o.a
 PKG_LIBS = -L$(LIBDIR) -lh3o
 
@@ -7,7 +8,11 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	cargo build --lib --release --manifest-path=./rust/Cargo.toml
+	# In some environments, ~/.cargo/bin might not be included in PATH, so we need
+	# to set it here to ensure cargo can be invoked. It is appended to PATH and
+	# therefore is only used if cargo is absent from the user's PATH.
+	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
+		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,0 +1,5 @@
+# Rtools42 doesn't have the linker in the location that cargo expects, so we
+# need to overwrite it via configuration.
+CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
+
+include Makevars.win

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,14 +1,28 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
-LIBDIR = ./rust/target/$(TARGET)/release
+
+TARGET_DIR = ./rust/target
+LIBDIR = $(TARGET_DIR)/$(TARGET)/release
 STATLIB = $(LIBDIR)/libh3o.a
-PKG_LIBS = -L$(LIBDIR) -lh3o -lws2_32 -ladvapi32 -luserenv
+PKG_LIBS = -L$(LIBDIR) -lh3o -lws2_32 -ladvapi32 -luserenv -lbcrypt
 
 all: C_clean
 
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml
+	mkdir -p $(TARGET_DIR)/libgcc_mock
+	# `rustc` adds `-lgcc_eh` flags to the compiler, but Rtools' GCC doesn't have
+	# `libgcc_eh` due to the compilation settings. So, in order to please the
+	# compiler, we need to add empty `libgcc_eh` to the library search paths.
+	#
+	# For more details, please refer to
+	# https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
+	touch $(TARGET_DIR)/libgcc_mock/libgcc_eh.a
+
+	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
+	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
+		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
+		cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/src/h3o-win.def
+++ b/src/h3o-win.def
@@ -1,0 +1,2 @@
+EXPORTS
+R_init_h3o


### PR DESCRIPTION
These files are generated with `rextendr` verison: 0.2.0.9000.

